### PR TITLE
fix/SOD#11: remove duplicate titles from markdown files (Suggestion)

### DIFF
--- a/content/docs/guides/_index.md
+++ b/content/docs/guides/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Guides"
+
 description: "How-to guides, onboarding documentation, and contribution guidelines"
 weight: 50
 ---

--- a/content/docs/meetings/2025-08/_index.md
+++ b/content/docs/meetings/2025-08/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "August 2025 Meetings"
+
 description: "Meeting notes and minutes for August 2025"
 ---
 

--- a/content/docs/poc/feature-x-prototype/_index.md
+++ b/content/docs/poc/feature-x-prototype/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Feature X Prototype"
+
 description: "Documentation for Feature X proof of concept"
 ---
 

--- a/content/docs/poc/integration-test-results/_index.md
+++ b/content/docs/poc/integration-test-results/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Integration Test Results"
+
 description: "Documentation of integration testing outcomes"
 ---
 

--- a/content/docs/research/market-analysis/_index.md
+++ b/content/docs/research/market-analysis/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Market Analysis"
+
 description: "Market research and competitive analysis"
 ---
 

--- a/content/docs/research/technology-evaluations/_index.md
+++ b/content/docs/research/technology-evaluations/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Technology Evaluations"
+
 description: "Technical research and technology stack evaluations"
 ---
 


### PR DESCRIPTION
## Fix Duplicate Page Title

Implements #11

### Description
The site was displaying **two titles** on content pages:
- One from the markdown file (`title:` in frontmatter)
- One from the Hugo/Hextra theme

This caused visual duplication and redundancy.

### Changes
- Removed `title:` field from all `.md` files in `/project-docs/content/docs/`
- Ensured page titles are now **only rendered by the theme** (clean and consistent)

### Result
- Only **one title** is displayed per page
- Cleaner UI and better SEO control
- No impact on navigation or content

### Testing
- Verified locally with `hugo server run`
- All pages now show a single, properly styled title

